### PR TITLE
Derive QueryId for Geography sqltype

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Diesel support for PostGIS geography types and functions
+//! Diesel support for PostGIS geography types and functions.
 
 #![allow(proc_macro_derive_resolution_fallback)]
 

--- a/src/sql_types.rs
+++ b/src/sql_types.rs
@@ -1,3 +1,5 @@
-#[derive(SqlType)]
+//! SQL Types.
+
+#[derive(SqlType, QueryId)]
 #[postgres(type_name = "geography")]
 pub struct Geography;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+//! Rust Types.
+
 use std::io::prelude::*;
 use std::convert::From;
 use diesel::deserialize::{self, FromSql};


### PR DESCRIPTION
Without this I cannot do raw queries with `QueryableByName` types.