### PR TITLE
bump postgis version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["database"]
 
 [dependencies]
 diesel = { version = "1.3", features = ["postgres"] }
-postgis = "0.6"
+postgis = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
postgis 0.8 bumps poostgres to 0.19, which drops a yanked hmac version which was dependency of postgres 0.15. Not doing this update caused my build to break. Hopefully this change does not negatively impact another area, though I haven't had a chance to check yet.